### PR TITLE
fix build path for api enclave

### DIFF
--- a/container/api/enclave_manifest.json
+++ b/container/api/enclave_manifest.json
@@ -11,12 +11,12 @@
       "x86_64": {
         "file_path": "container/dockerapp/api",
         "file_name": "Dockerfile",
-        "build_path": ""
+        "build_path": "container/dockerapp/api"
       },
       "aarch64": {
         "file_path": "container/dockerapp/api",
         "file_name": "Dockerfile",
-        "build_path": ""
+        "build_path": "container/dockerapp/api"
       }
     }
   }


### PR DESCRIPTION
## Summary
- point api enclave build path at docker app directory

## Testing
- `./enclavectl build --image api` *(fails: docker not found)*
- `apt-get update` *(fails: The repository ... is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68986aae0fe883259601057d9a38d3f2