### PR TITLE
Simplify API module by removing AWS dependencies

### DIFF
--- a/container/dockerapp/api/go.mod
+++ b/container/dockerapp/api/go.mod
@@ -1,8 +1,3 @@
 module api
 
 go 1.20
-
-require (
-    github.com/aws/aws-nitro-enclaves-sdk-go v0.7.0
-    github.com/aws/aws-sdk-go v1.50.0
-)


### PR DESCRIPTION
## Summary
- replace AWS SDK and Nitro Enclaves session with local AES-GCM encryption
- streamline API module's `go.mod` to use only the Go standard library

## Testing
- `go mod tidy`
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_68986d369820832597df3c460b083c93