### PR TITLE
Normalize setup UUID to lowercase for Docker compatibility

### DIFF
--- a/enclavectl
+++ b/enclavectl
@@ -137,11 +137,15 @@ try_create_setup_uuid() {
   CONFIG_SETUP_UUID=""
 
   # Try loading the UUID from file.
-  [[ -f $WORKING_DIR/$FILE_SETUP_ID ]] && { CONFIG_SETUP_UUID=$(<"$WORKING_DIR/$FILE_SETUP_ID"); }
+  [[ -f $WORKING_DIR/$FILE_SETUP_ID ]] && {
+    CONFIG_SETUP_UUID=$(<"$WORKING_DIR/$FILE_SETUP_ID")
+    CONFIG_SETUP_UUID=$(to_lower_case "$CONFIG_SETUP_UUID")
+  }
 
   [[ "${CONFIG_SETUP_UUID}" != "" ]] || {
     say "Setup UUID doesn't exist. Creating one..."
     CONFIG_SETUP_UUID=$(uuidgen)
+    CONFIG_SETUP_UUID=$(to_lower_case "$CONFIG_SETUP_UUID")
   }
 
   # Check if the UUID is valid.
@@ -175,7 +179,7 @@ try_load_configuration() {
   }
 
   [[ -f "$WORKING_DIR/$FILE_CONFIGURATION" ]] && \
-      CONFIG_SETUP_UUID=$(<"$WORKING_DIR/$FILE_SETUP_ID");
+      CONFIG_SETUP_UUID=$(to_lower_case "$(cat "$WORKING_DIR/$FILE_SETUP_ID")");
 }
 
 cmd_configure() {

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -25,6 +25,10 @@ to_upper_case() {
   echo $1 | awk '{print toupper($0)}'
 }
 
+to_lower_case() {
+  echo $1 | awk '{print tolower($0)}'
+}
+
 # ######################################################
 
 # Send an error-decorated text message to stderr


### PR DESCRIPTION
## Summary
- ensure setup UUID is stored in lowercase to create valid Docker repository tags
- add `to_lower_case` helper for reuse

## Testing
- `bash -n enclavectl`
- `bash -n scripts/utils.sh`
- `./enclavectl help` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68986f239bfc83258980f0d8ff42de31