### PR TITLE
Run API binary in Dockerfile

### DIFF
--- a/container/dockerapp/api/Dockerfile
+++ b/container/dockerapp/api/Dockerfile
@@ -5,3 +5,5 @@ WORKDIR /app
 COPY go.mod .
 COPY main.go .
 RUN go build -o api
+
+CMD ["/app/api"]


### PR DESCRIPTION
## Summary
- run built api binary in Dockerfile

## Testing
- `go build -o api` (creates binary)
- `docker build -t api-test ./container/dockerapp/api` (fails: command not found: docker)


------
https://chatgpt.com/codex/tasks/task_e_6898c38801b4832589d9c72b2c63f715